### PR TITLE
Fix doc typo and sphere handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install pysearchlight
 
 PySearchlight takes care of moving the sphere across the data and applying the user-defined function to the data within the sphere. The user only needs to provide the data, the function to apply within the searchlight, and the radius of the searchlight sphere. The function should take a single argument, which is the data within the sphere centered at a voxel location. The function can also take additional arguments, which can be passed using `functools.partial`.
 
-Here is a simple example of how to use PySearchLight to train and evaluate classifier on data within a searchlight:
+Here is a simple example of how to use PySearchLight to train and evaluate a classifier on data within a searchlight:
 
 ```python
 import numpy as np

--- a/src/pysearchlight/__init__.py
+++ b/src/pysearchlight/__init__.py
@@ -1,1 +1,2 @@
-from .sl import Searchlight
+# Re-export the main SearchLight class
+from .sl import SearchLight

--- a/tests/test_sl.py
+++ b/tests/test_sl.py
@@ -1,0 +1,12 @@
+import numpy as np
+from pysearchlight.sl import SearchLight
+
+def dummy(data):
+    return 0
+
+def test_get_sphere_coords_size_consistency():
+    data = np.zeros((5, 5, 5, 1))
+    sl = SearchLight(data=data, sl_fn=dummy, radius=1)
+    center = sl.get_sphere_coords(2, 2, 2)
+    edge = sl.get_sphere_coords(0, 0, 0)
+    assert len(center) == len(edge)


### PR DESCRIPTION
## Summary
- fix a README typo
- avoid exhaustion of searchlight coordinate generator
- clarify `get_searchlight_data` docs
- expose correct class name in package init
- add a regression test for sphere coordinate handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f4424af848327bff6fca7a24d1ff1